### PR TITLE
RF51: Consultar todos los proyectos

### DIFF
--- a/src/components/common/CardsGrid.tsx
+++ b/src/components/common/CardsGrid.tsx
@@ -12,7 +12,7 @@ interface CardsGridProps {
 
 const CardsGrid = ({ children }: CardsGridProps) => {
   return (
-    <section className='grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 bg-white rounded-xl shadow-xl p-7'>
+    <section className='grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 bg-white rounded-xl shadow-xl p-7 flex-1 min-h-0 overflow-y-scroll'>
       {children}
     </section>
   );

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -27,7 +27,7 @@ const Layout = ({ children }: LayoutProps) => {
       <SideBar />
       <div className='flex flex-col h-full flex-1 px-14 pb-14'>
         <Header pageTitle={pathToText()} />
-        <section className='flex flex-col flex-1 mt-3'>{children}</section>
+        <section className='flex flex-col flex-1 mt-3 min-h-0'>{children}</section>
       </div>
     </main>
   );

--- a/src/components/modules/Projects/ProjectCard.tsx
+++ b/src/components/modules/Projects/ProjectCard.tsx
@@ -1,0 +1,85 @@
+import Chip from '@mui/joy/Chip';
+import { Link } from 'react-router-dom';
+import colors from '../../../colors';
+import { ProjectAreas, ProjectStatus } from '../../../types/project';
+
+type CardProjectProps = {
+  name: string;
+  status: ProjectStatus;
+  department: ProjectAreas;
+  company: string;
+  id: string;
+};
+
+const getStatusColor = (status: ProjectStatus) => {
+  switch (status) {
+    case ProjectStatus.DONE:
+      return colors.success;
+    case ProjectStatus.IN_QUOTATION:
+      return colors.darkerBlue;
+    case ProjectStatus.ACCEPTED:
+      return colors.gold;
+    case ProjectStatus.NOT_STARTED:
+      return colors.notStarted;
+    case ProjectStatus.IN_PROCESS:
+      return colors.darkBlue;
+    case ProjectStatus.UNDER_REVISION:
+      return colors.darkPurple;
+    case ProjectStatus.DELAYED:
+      return colors.delayed;
+    case ProjectStatus.POSTPONED:
+      return colors.lightRed;
+    case ProjectStatus.CANCELLED:
+      return colors.danger;
+    default:
+      return colors.gray;
+  }
+};
+
+const getColorArea = (department: ProjectAreas) => {
+  switch (department) {
+    case ProjectAreas.ACCOUNTING:
+      return colors.darkGold;
+    case ProjectAreas.CLIENT:
+      return colors.darkPurple;
+    case ProjectAreas.LEGAL:
+      return colors.darkerGold;
+    default:
+      return colors.darkestGray;
+  }
+};
+
+/**
+ * Client Card component
+ *
+ * @component
+ * @param props - Component props
+ * @param props.name - The name of the client
+ * @param props.status - The status of the project
+ * @param props.department - The areas of the organization
+ *
+ * @returns Client Card component
+ */
+const ProjectCard = ({ name, status, department, company, id }: CardProjectProps): JSX.Element => {
+  return (
+    <Link to={`/projects/${id}`}>
+      <section className='bg-[#EFEFEF] hover:bg-[#DEDEDE] rounded-lg p-4'>
+        <section className='flex gap-3'>
+          <div className='border-2 h-8 border-[#9C844C]' />
+          <h5 className='text-[#424242] font-montserrat'>{name}</h5>
+        </section>
+        <span className='text-sm text-gold'>{company}</span>
+        <section className='mt-3 flex gap-3'>
+          <Chip variant='solid' sx={{ 'background-color': getStatusColor(status) }}>
+            {status}
+          </Chip>
+          <Chip variant='solid' sx={{ 'background-color': getColorArea(department) }}>
+            {department}
+          </Chip>
+        </section>
+      </section>
+    </Link>
+  );
+};
+
+export default ProjectCard;

--- a/src/pages/Clients/index.tsx
+++ b/src/pages/Clients/index.tsx
@@ -28,7 +28,7 @@ const Clients = () => {
       <Route
         path='/'
         element={
-          <main className='p-10 py-0 flex flex-col'>
+          <main className='p-10 py-0 flex flex-col min-h-0 flex-1'>
             <section className='flex flex-row justify-end p-5 gap-6'>
               <button>Not Archived</button>
               <AddButton />

--- a/src/pages/Projects/index.tsx
+++ b/src/pages/Projects/index.tsx
@@ -1,24 +1,12 @@
-import { Link, Route, Routes } from 'react-router-dom';
-import AddButton from '../../components/common/AddButton';
-import { RoutesPath } from '../../utils/constants';
+import { Route, Routes } from 'react-router-dom';
+import ProjectMain from './main';
 import NewProject from './new';
 import ProjectReport from './report';
 
 const Projects = () => {
   return (
     <Routes>
-      <Route
-        path='/'
-        element={
-          <main className='flex gap-4'>
-            <h1>Projects Page</h1>
-            <p>Welcome to the Projects page!</p>
-            <Link to={`${RoutesPath.PROJECTS}/new`}>
-              <AddButton></AddButton>
-            </Link>
-          </main>
-        }
-      />
+      <Route path='/' element={<ProjectMain />} />
       <Route path='/new' element={<NewProject />} />
       <Route path='/report/:id' element={<ProjectReport />} />
     </Routes>

--- a/src/pages/Projects/main.tsx
+++ b/src/pages/Projects/main.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import AddButton from '../../components/common/AddButton';
+import Loader from '../../components/common/Loader';
+import ProjectCard from '../../components/modules/Projects/ProjectCard';
+import useFetch from '../../hooks/useFetch';
+import { ProjectEntity } from '../../types/project';
+import { RoutesPath } from '../../utils/constants';
+
+const ProjectMain = () => {
+  const req = useFetch<ProjectEntity[]>('http://localhost:4000/api/v1/project');
+  const [companyNames, setCompanyNames] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(req.isLoading);
+  useEffect(() => {
+    async function getNames() {
+      setIsLoading(true);
+      const res: string[] = [];
+      if (req.data) {
+        for (const project of req.data) {
+          const r = await fetch(`http://localhost:4000/api/v1/company/${project.idCompany}`);
+          const d = await r.json();
+          res.push(d.name);
+        }
+        setCompanyNames(res);
+        setIsLoading(false);
+      }
+    }
+    getNames();
+  }, [req.data]);
+  return (
+    <main className='flex flex-col gap-4 flex-1 min-h-0'>
+      <section className='h-10 flex justify-end'>
+        <Link to={`${RoutesPath.PROJECTS}/new`}>
+          <AddButton></AddButton>
+        </Link>
+      </section>
+      <section className='flex-1 overflow-scroll'>
+        <div className='bg-[#FAFAFA] rounded-xl overflow-y-scroll grid grid-cols-3 flex-1 min-h-0 shadow-lg p-4 gap-5'>
+          {isLoading && <Loader />}
+          {!isLoading &&
+            req.data?.map((project, i) => (
+              <ProjectCard
+                key={project.id}
+                id={project.id}
+                company={companyNames[i]}
+                department={project.area}
+                name={project.name}
+                status={project.status}
+              />
+            ))}
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default ProjectMain;

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -35,6 +35,8 @@ export enum ProjectStatus {
   POSTPONED = 'Postponed',
   DONE = 'Done',
   CANCELLED = 'Cancelled',
+  IN_QUOTATION = 'In quotation',
+  ACCEPTED = 'Accepted',
 }
 
 export interface ProjectEntity {
@@ -46,7 +48,7 @@ export interface ProjectEntity {
   category: string;
   startDate: Date;
   endDate: Date;
-  area: string;
+  area: ProjectAreas;
   totalHours: number;
   periodicty: ProjectPeriodicity;
   isChargeable: boolean;


### PR DESCRIPTION
## Pull Request Titulo

[RF51]: Consultar todos los proyectos

### Descripción

Se creo la vista de consultar todos los proyectos.

### Cambios realizados

- Se cambió el layout para que el overflow se haga de manera correcta
- Se creo el componente de cada card de proyecto 
- Se creó la vista de todos los proyectos
- Se realizó el fetch de los datos desde el backend.

### Story Points

7

### Criterios de aceptación

- [x] El sistema permite acceder a los usuarios a la página de  “Projets” desde la sidebar.
- [x] Se muestra la pantalla con la lista de todos los proyectos ordenados por status (el status de “Done” debe de ser el último que aparece).
- [x] Se muestra el botón de agregar un nuevo proyecto.

### Dependencias

Ninguna

### Definición de Done

- [ ] El código ha sido revisado por al menos un miembro del equipo.
- [ ] Todas las pruebas pasan localmente.
- [ ] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [ ] La documentación ha sido actualizada (si corresponde).
- [ ] Cualquier nueva dependencia está documentada y justificada.
- [ ] Los cambios han sido probados en un entorno de preparación (si corresponde).

### ScreenShot de la pagina 
<img width="1512" alt="Captura de pantalla 2024-04-26 a la(s) 19 19 52" src="https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/80234551/7608e31a-563d-4615-a5bf-02f01101a866">
