### PR TITLE
Style Projects

### DIFF
--- a/src/components/modules/Projects/ProjectCard.tsx
+++ b/src/components/modules/Projects/ProjectCard.tsx
@@ -34,19 +34,6 @@ const getStatusColor = (status: ProjectStatus) => {
   }
 };
 
-const getColorArea = (department: ProjectAreas) => {
-  switch (department) {
-    case ProjectAreas.ACCOUNTING:
-      return colors.darkGold;
-    case ProjectAreas.CLIENT:
-      return colors.darkPurple;
-    case ProjectAreas.LEGAL:
-      return colors.darkerGold;
-    default:
-      return colors.darkestGray;
-  }
-};
-
 /**
  * Client Card component
  *
@@ -70,7 +57,14 @@ const ProjectCard = ({ name, status, department, company }: CardProjectProps): J
         <Chip variant='solid' sx={{ 'background-color': getStatusColor(status) }}>
           {status}
         </Chip>
-        <Chip variant='solid' sx={{ 'background-color': getColorArea(department) }}>
+        <Chip
+          variant='solid'
+          sx={{
+            'background-color': colors.lightGold,
+            textTransform: 'lowercase',
+            color: colors.darkerGold,
+          }}
+        >
           {department}
         </Chip>
       </section>

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -28,9 +28,9 @@ export enum ProjectAreas {
 }
 
 export enum ProjectStatus {
-  NOT_STARTED = 'Not Started',
-  IN_PROCESS = 'In Process',
-  UNDER_REVISION = 'Under Revision',
+  NOT_STARTED = 'Not started',
+  IN_PROCESS = 'In process',
+  UNDER_REVISION = 'Under revision',
   DELAYED = 'Delayed',
   POSTPONED = 'Postponed',
   DONE = 'Done',


### PR DESCRIPTION
## Style Projects

### Descripción
Arreglar el color de los chips.

### Cambios realizados
- el color del status ya funciona.
- el color del chip de area legal y contable es el mismo
- se cambió a minúsculas el área

### Comentarios
- no quise borrar client del enum de ProjectArea porque no se si afecte a algo.
-

### ScreenShot de la pagina 
<img width="1295" alt="Captura de pantalla 2024-05-01 a la(s) 6 46 49 p m" src="https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/105307730/8a1e2a78-ece0-4604-884d-e2a233544f03">

