### PR TITLE
fix(ModifyClient): actualización automática sin necesidad de refresh

### DIFF
--- a/src/components/modules/Clients/EditClientFormModal.tsx
+++ b/src/components/modules/Clients/EditClientFormModal.tsx
@@ -87,7 +87,7 @@ const EditClientFormModal = ({
       taxResidence: companyTaxResidence,
     };
 
-    await sendRequest({}, updatedClientData);
+    await sendRequest({ method: 'PUT' }, updatedClientData);
   };
   return (
     <Modal

--- a/src/components/modules/Clients/EditClientFormModal.tsx
+++ b/src/components/modules/Clients/EditClientFormModal.tsx
@@ -73,7 +73,23 @@ const EditClientFormModal = ({
       !companyConstitution ||
       !companyTaxResidence
     ) {
-      setState({ open: true, message: 'The name field is required.', type: 'danger' });
+      setState({ open: true, message: 'All fields are required.', type: 'danger' });
+      return;
+    }
+
+    if (companyPhone.length < 8) {
+      setState({
+        open: true,
+        message: 'Phone number must have at least 8 characters.',
+        type: 'danger',
+      });
+      return;
+    } else if (companyPhone.length > 15) {
+      setState({
+        open: true,
+        message: 'Phone number must have at most 15 characters.',
+        type: 'danger',
+      });
       return;
     }
 
@@ -87,7 +103,7 @@ const EditClientFormModal = ({
       taxResidence: companyTaxResidence,
     };
 
-    await sendRequest({ method: 'PUT' }, updatedClientData);
+    await sendRequest({ method: RequestMethods.PUT }, updatedClientData);
   };
   return (
     <Modal
@@ -172,6 +188,7 @@ const EditClientFormModal = ({
               variant='outlined'
               value={companyTaxResidence}
               onChange={e => setCompanyTaxResidence(e.target.value)}
+              inputProps={{ maxLength: 13 }}
             />
           </Box>
 

--- a/src/pages/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/pages/Clients/ClientDetails/ClientDetails.tsx
@@ -41,6 +41,7 @@ const ClientDetails = ({ clientId }: ClientDetailProps) => {
   const [open, setOpen] = useState<boolean>(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [company, setCompany] = useState<CompanyEntity | null>(null);
+  const [refetch, setRefetch] = useState(false);
   const { data, error, loading, sendRequest } = useHttp<Response<CompanyEntity>>(
     `/company/${clientId}`,
     RequestMethods.GET
@@ -53,7 +54,7 @@ const ClientDetails = ({ clientId }: ClientDetailProps) => {
   useEffect(() => {
     sendRequest();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [refetch]);
 
   useEffect(() => {
     if (data && data.data) {
@@ -102,7 +103,7 @@ const ClientDetails = ({ clientId }: ClientDetailProps) => {
                 open={editModalOpen}
                 setOpen={setEditModalOpen}
                 clientData={company}
-                setRefetch={() => {}}
+                setRefetch={setRefetch}
               />
             )}
             <ArchiveOutlinedIcon


### PR DESCRIPTION
## Refactor actualizar cliente

fix(ModifyClient): actualización automática sin necesidad de refresh

### Descripción

Se resolvió el problema de que no se actualizaba hasta que se hiciera un 

### Cambios realizados

-Se añadió estado refetch en ClientDetails para actualizar los datos del cliente automáticamente tras cerrar el modal de edición.
- Implementación de método PUT en handleUpdate de EditClientFormModal para asegurar la actualización de datos del cliente.
- Propagación de setRefetch a EditClientFormModal para permitir la recarga de datos en ClientDetails sin necesidad de refresh manual.

### ScreenShot de la pagina 


https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/105307730/8eac8f63-1fe9-49c3-9515-672f4852ef48


