### PR TITLE
Feat/rf57 filter archived clients

### DIFF
--- a/src/pages/Clients/index.tsx
+++ b/src/pages/Clients/index.tsx
@@ -1,3 +1,6 @@
+import Option from '@mui/joy/Option';
+import Select from '@mui/joy/Select';
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { Link, Route, Routes } from 'react-router-dom';
 import AddButton from '../../components/common/AddButton';
@@ -7,25 +10,51 @@ import Loader from '../../components/common/Loader';
 import NewClientFormModal from '../../components/modules/Clients/NewClientFormModal';
 import useHttp from '../../hooks/useHttp';
 import { CompanyEntity } from '../../types/company';
-import { RequestMethods, RoutesPath } from '../../utils/constants';
+import { EnvKeysValues, RequestMethods, RoutesPath } from '../../utils/constants';
 import ClientDetails from './ClientDetails/ClientDetails';
 
 const Clients = () => {
   const [clientId, setClientId] = useState<string>('');
 
-  const { data, error, loading, sendRequest } = useHttp<CompanyEntity[]>(
-    '/company',
-    RequestMethods.GET
-  );
+  const [companies, setClientsData] = useState<CompanyEntity[]>();
 
-  const companies: CompanyEntity[] = data ? data.flat() : [];
+  const clientsRequest = useHttp<CompanyEntity[]>('/company/', RequestMethods.GET);
+
   const [open, setOpen] = useState(false);
   const [refetch, setRefetch] = useState(false);
 
+  const handleClose = (event: React.SyntheticEvent | null, value: string | null) => {
+    const doFetch = async (value: string | null): Promise<void> => {
+      if (value === 'Not Archived') {
+        const data = await axios.get(`${EnvKeysValues.BASE_API_URL}/company/`, {
+          headers: { Authorization: `Bearer ${sessionStorage.getItem('idToken')}` },
+        });
+        setClientsData(data.data);
+      } else {
+        const data = await axios.get(`${EnvKeysValues.BASE_API_URL}/company/archived`, {
+          headers: { Authorization: `Bearer ${sessionStorage.getItem('idToken')}` },
+        });
+        setClientsData(data.data);
+      }
+    };
+    void doFetch(value);
+  };
+
   useEffect(() => {
-    sendRequest();
+    clientsRequest.sendRequest();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refetch]);
+
+  useEffect(() => {
+    if (!clientsRequest.data) {
+      clientsRequest.sendRequest();
+    } else {
+      setClientsData(clientsRequest.data);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientsRequest.data]);
+
+  useEffect(() => {}, [handleClose]);
 
   const openModal = () => {
     setOpen(true);
@@ -38,16 +67,19 @@ const Clients = () => {
         element={
           <main className='py-0 flex flex-col min-h-0 flex-1'>
             <section className='flex flex-row justify-end mb-8 gap-6'>
-              <button>Not Archived</button>
+              <Select defaultValue='Not Archived' onChange={handleClose}>
+                <Option value='Not Archived'>Not Archived</Option>
+                <Option value='Archived'>Archived</Option>
+              </Select>
               <AddButton onClick={openModal} />
             </section>
             <NewClientFormModal open={open} setOpen={setOpen} setRefetch={setRefetch} />
 
             <div className='flex justify-center w-full'>
-              {loading && <Loader />}
-              {error && <p>Error loading companies.</p>}
+              {clientsRequest.loading && <Loader />}
+              {clientsRequest.error && <p>Error loading companies.</p>}
             </div>
-            {!loading && !error && companies && (
+            {!clientsRequest.loading && !clientsRequest.error && companies && (
               <CardsGrid>
                 {companies.map(company => (
                   <Link

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -27,3 +27,9 @@ export interface UpdateCompanyData {
   rfc?: string | null;
   taxResidence?: string | null;
 }
+
+export enum CompanyFilters {
+  ARCHIVED = 'Archived',
+  NOT_ARCHIVED = 'Not Archived',
+  ALL = 'All',
+}


### PR DESCRIPTION
## RF57: Filtrar clientes archivados y no archivados

[RF57]: Se crea un dropdown para seleccionar entre mostrar clientes (todos/no archivados/archivados)

### Descripción

Se crea un dropdown para seleccionar entre mostrar clientes (todos/no archivados/archivados). En la vista de lista de clientes, el sistema muestra un filtro para poder observar ya sea los clientes “archivados” o “no archivados”


### Cambios realizados

- Se modifica `src/pages/Clients/index.tsx`

### Story Points

5

### Criterios de aceptación

- [X] En la vista de lista de clientes, el sistema muestra un filtro para poder observar ya sea los clientes “archivados” o “no archivados”

### Dependencias

Enumera cualquier dependencia o PR relacionado que deba fusionarse antes o después de este PR.

### Definición de Done

- [X] El código ha sido revisado por al menos un miembro del equipo.
- [X] Todas las pruebas pasan localmente.
- [X] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [x] La documentación ha sido actualizada (si corresponde).
- [x] Cualquier nueva dependencia está documentada y justificada.
- [X] Los cambios han sido probados en un entorno de preparación (si corresponde).

### ScreenShot de la pagina 

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91692094/5e3e6b0b-813f-49f4-95ac-bc07998f6000

