### PR TITLE
Fix: RF05 Bugs

### DIFF
--- a/src/components/common/ModifyButton.tsx
+++ b/src/components/common/ModifyButton.tsx
@@ -3,6 +3,7 @@ import colors from '../../colors';
 
 interface ModifyButtonProps {
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 /**
@@ -13,11 +14,12 @@ interface ModifyButtonProps {
  * @param props: Object - The component props
  * @returns
  */
-const ModifyButton = ({ onClick }: ModifyButtonProps) => {
+const ModifyButton = ({ onClick, disabled }: ModifyButtonProps) => {
   return (
     <Button
       variant='contained'
       onClick={onClick}
+      disabled={disabled}
       sx={{
         bgcolor: colors.darkGold,
         color: '#fff',

--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -58,10 +58,24 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value);
+    if (!event.target.value.trim()) {
+      setErrors(prevErrors => ({ ...prevErrors, title: 'Title is required' }));
+      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+    } else {
+      setErrors(prevErrors => ({ ...prevErrors, title: '' }));
+      setState({ open: false, message: '' });
+    }
   };
 
   const handleDescriptionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setDescription(event.target.value);
+    if (!event.target.value.trim()) {
+      setErrors(prevErrors => ({ ...prevErrors, description: 'Description is required' }));
+      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+    } else {
+      setErrors(prevErrors => ({ ...prevErrors, description: '' }));
+      setState({ open: false, message: '' });
+    }
   };
 
   const handleStartDateChange = (date: dayjs.Dayjs | null) => {
@@ -82,6 +96,14 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
 
   const handleWorkedHoursChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setWorkedHours(event.target.value);
+
+    if (!event.target.value.trim()) {
+      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
+      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+    } else {
+      setErrors(prevErrors => ({ ...prevErrors, workedHours: '' }));
+      setState({ open: false, message: '' });
+    }
   };
 
   const getEmployeeNames = () => {
@@ -109,23 +131,6 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleSubmit = async () => {
-    const requiredFields = [
-      'title',
-      'description',
-      'startDate',
-      'dueDate',
-      'status',
-      'projectName',
-    ];
-
-    if (!requiredFields.every(field => !!field && field !== '')) {
-      setErrors({
-        ...errors,
-        ...requiredFields.reduce((acc, field) => ({ ...acc, [field]: `${field} is required` }), {}),
-      });
-      return;
-    }
-
     if (dueDate && startDate && dueDate.isBefore(startDate)) {
       setErrors({
         ...errors,
@@ -162,13 +167,11 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleCancel = () => {
-    setTitle('');
-    setDescription('');
-    setStartDate(null);
-    setDueDate(null);
-    setStatus('');
-    setAssignedEmployee('');
-    setWorkedHours(null);
+    navigate(RoutesPath.TASKS);
+  };
+
+  const hasErrors = () => {
+    return Object.values(errors).some(error => !!error);
   };
 
   return (
@@ -285,7 +288,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
         </Grid>
         <Grid>
           <Item>
-            <ModifyButton onClick={handleSubmit} />
+            <ModifyButton onClick={handleSubmit} disabled={hasErrors()} />
           </Item>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Fix RF05 Bugs

[Issue 159]: Botón cancelar en Update Task
[Issue 165]: Campos no validados en Update Task

### Descripción

Se arregló el defecto [159](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?filterQuery=assignee%3A%40me&pane=issue&itemId=62200923) y el defecto [165](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?filterQuery=assignee%3A%40me&pane=issue&itemId=62211235).

### Cambios realizados

- Se agregó un navigate a tasks si se presiona el botón cancelar.
- Se modificó la lógica de validación de campos en el formulario.
- Se desactivó el botón de envío si los campos están vacíos.

### ScreenShot de la pagina 


https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/93755653/c7777570-d134-4260-af84-6ec6cdcbdd59

