### PR TITLE
Fix/rf05 update task

### DIFF
--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -1,7 +1,7 @@
 import { Grid, Input, Snackbar, Textarea } from '@mui/joy';
 import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { default as colors, statusChipColorCombination } from '../../../../colors';
 import { SnackbarContext, SnackbarState } from '../../../../hooks/snackbarContext';
 import { EmployeeEntity } from '../../../../types/employee';
@@ -43,7 +43,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   employees,
   data,
 }: UpdateTaskFormProps): JSX.Element => {
-  const { idTask } = useParams();
+  const idTask = data.id;
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [startDate, setStartDate] = useState<dayjs.Dayjs | null>(null);
@@ -159,7 +159,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
       await onSubmit(payload);
       setState({ open: true, message: 'Task updated successfully.', type: 'success' });
       setTimeout(() => {
-        navigate(RoutesPath.TASKS);
+        navigate(RoutesPath.TASKS + '/' + idTask);
       }, 2000);
     } catch (error) {
       setState({ open: true, message: 'Failed to update task.', type: 'danger' });
@@ -167,7 +167,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleCancel = () => {
-    navigate(RoutesPath.TASKS);
+    navigate(RoutesPath.TASKS + '/' + idTask);
   };
 
   const hasErrors = () => {


### PR DESCRIPTION
## Fix RF05 Bad Redirect

[Issue 173]: Bad buttons redirect

### Descripción

Se arregló el defecto [173](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?filterQuery=assignee%3A%40me&pane=issue&itemId=62218482).

### Cambios realizados

- El botón de cancelar en actualizar tarea ahora redirije a la pantalla anterior.
- El botón de modify en actualizar tarea ahora redirije a la pantalla anterior.