### PR TITLE
RF03: Status can now be updated on assigned tasks page

### DIFF
--- a/src/components/modules/Task/TableTask/TaskTable.tsx
+++ b/src/components/modules/Task/TableTask/TaskTable.tsx
@@ -1,4 +1,5 @@
 import { KeyboardArrowDown } from '@mui/icons-material';
+import { Snackbar } from '@mui/joy';
 import {
   Card,
   Chip,
@@ -11,11 +12,14 @@ import {
   Typography,
   colors,
 } from '@mui/material';
-import { useState } from 'react';
+import axios, { AxiosRequestConfig } from 'axios';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { statusChipColorCombination } from '../../../../colors';
+import { SnackbarContext, SnackbarState } from '../../../../hooks/snackbarContext';
 import { Task } from '../../../../types/task';
 import { TaskStatus } from '../../../../types/task-status';
+import { APIPath, RequestMethods } from '../../../../utils/constants';
 import DeleteModal from '../../../common/DeleteModal';
 import GenericDropdown from '../../../common/GenericDropdown';
 import TaskActionsMenu from '../../../common/TaskActionsMenu';
@@ -37,10 +41,15 @@ interface TaskTableProps {
 
 const TaskTable = ({ tasks, onDelete }: TaskTableProps) => {
   const navigate = useNavigate();
+  const idTaskPayload = useRef<string>('');
+
   const [collapsed, setCollapsed] = useState(false);
+  const [state, setState] = useState<SnackbarState>({ open: false, message: '' });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [newStatus, setNewStatus] = useState<TaskStatus | null>(null);
   const [taskToDelete, setTaskToDelete] = useState<Task | null>(null);
 
   const handleClick = (id: string) => {
@@ -63,6 +72,47 @@ const TaskTable = ({ tasks, onDelete }: TaskTableProps) => {
     const year = date.getFullYear();
 
     return `${day}-${month}-${year}`;
+  };
+
+  const handleStatusChange = async (idTask: string, status: TaskStatus | null) => {
+    setNewStatus(status);
+
+    if (idTask.trim() !== '') {
+      idTaskPayload.current = idTask;
+
+      const payload = {
+        status: status as TaskStatus,
+      };
+
+      try {
+        await doFetch(payload);
+        setState({ open: true, message: 'Task status updated successfully.', type: 'success' });
+        setTimeout(() => {
+          setState({ open: false, message: '' });
+        }, 2000);
+      } catch (error) {
+        setState({ open: true, message: 'Failed to update status task.', type: 'danger' });
+        console.error(error);
+      }
+    } else {
+      console.error('Empty idTask received.');
+    }
+  };
+
+  const doFetch = async (payload: { status: TaskStatus }) => {
+    const BASE_URL = import.meta.env.VITE_BASE_API_URL as string;
+    const idToken = localStorage.getItem('idToken');
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${idToken}`,
+    };
+    const options: AxiosRequestConfig = {
+      method: RequestMethods.PUT,
+      url: `${BASE_URL}${APIPath.UPDATE_TASK_STATUS}/${idTaskPayload.current}`,
+      headers: headers,
+      data: payload,
+    };
+    await axios(options);
   };
 
   return (
@@ -114,7 +164,7 @@ const TaskTable = ({ tasks, onDelete }: TaskTableProps) => {
                       <GenericDropdown
                         options={Object.values(TaskStatus)}
                         defaultValue={task.status}
-                        onValueChange={() => {}}
+                        onValueChange={value => handleStatusChange(task.id, value)}
                         colorMap={statusColorMap}
                       />
                     </TableCell>
@@ -150,6 +200,12 @@ const TaskTable = ({ tasks, onDelete }: TaskTableProps) => {
           setTaskToDelete(null);
         }}
       />
+      {/* Snackbar */}
+      <SnackbarContext.Provider value={{ state, setState }}>
+        <Snackbar open={state.open} color={state.type ?? 'neutral'} variant='solid'>
+          {state.message}
+        </Snackbar>
+      </SnackbarContext.Provider>
     </>
   );
 };


### PR DESCRIPTION
## RF03: Status can now be updated on assigned tasks page

[RF03]: Task status now PUTs to backend when updated on tasks page

### Descripción

Se agregó la funcionalidad de actualización de estatus de tarea en la vista de detalle de tareas.

### Cambios realizados

- Se actualizó el componente TaskTable
- Se hace una request tipo PUT usando axios con el estado actualizado

### Story Points

5

### Criterios de aceptación

- [x] El sistema despliega las siguientes opciones de estatus:
  - Not started
  - In process
  - Under revision
  - Delay
  - Postponed
  - Done
  - Cancelled 
- [x] Tras seleccionar el nuevo estatus, el sistema guarda el cambio y la end day se actualiza al día en que se cambió a “Done”.
- [x] El sistema muestra un mensaje de éxito o error según el caso.

### Definición de Done

- [ ] El código ha sido revisado por al menos un miembro del equipo.
- [x] Todas las pruebas pasan localmente.
- [x] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [x] La documentación ha sido actualizada (si corresponde).
- [x] Cualquier nueva dependencia está documentada y justificada.
- [x] Los cambios han sido probados en un entorno de preparación (si corresponde).

### ScreenShot de la pagina 

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/93755653/c6d17446-6887-4a0f-80ca-560747419fe2)