### PR TITLE
refactor(GenericDropdownStyles): updated the generic dropdown styles

### DIFF
--- a/src/colors.tsx
+++ b/src/colors.tsx
@@ -39,7 +39,7 @@ export const statusChipColorCombination = {
   inProgerss: { bg: '#FFE598', font: '#896A10' },
   accepted: { bg: '#B7D7A8', font: '#53664B' },
   done: { bg: '#6AA84F', font: '#BCEFA6' },
-  postpone: { bg: '#A0C5E8', font: '#485A6C' },
+  postponed: { bg: '#A0C5E8', font: '#485A6C' },
   underRevision: { bg: '#D7B2F0', font: '#764D91' },
   inQuotation: { bg: '#878FD2', font: '#273086' },
   default: { bg: '#C4C4C4', font: '#424242' },

--- a/src/components/common/GenericDropdown.tsx
+++ b/src/components/common/GenericDropdown.tsx
@@ -100,7 +100,7 @@ const GenericDropdown = <T extends string | number>({
         renderValue={renderValue || renderValueWithColor}
         sx={{
           borderRadius: 30,
-          background: option && colorMap?.[option]?.bg || backgroundColor || 'transparent',
+          background: (option && colorMap?.[option]?.bg) || backgroundColor || 'transparent',
           '& .MuiSelect-select': {
             padding: '1px 6px',
             fontSize: '0.875rem',

--- a/src/components/common/GenericDropdown.tsx
+++ b/src/components/common/GenericDropdown.tsx
@@ -1,5 +1,11 @@
-import { Box, FormControl, MenuItem, Select, SelectChangeEvent, SelectProps } from '@mui/material';
+import { Box } from '@mui/joy';
+import { FormControl, MenuItem, Select, SelectChangeEvent, SelectProps } from '@mui/material';
 import React, { useEffect, useState } from 'react';
+
+interface ColorMapEntity {
+  bg: string;
+  font: string;
+}
 
 interface GenericDropdownProps<T extends string | number>
   extends Omit<SelectProps<T>, 'onChange' | 'value'> {
@@ -8,7 +14,7 @@ interface GenericDropdownProps<T extends string | number>
   onValueChange: (value: T) => void;
   renderValue?: (value: T) => React.ReactNode;
   placeholder?: string;
-  colorMap?: Record<T, string>;
+  colorMap?: Record<T, ColorMapEntity>;
   defaultValue?: T;
 }
 
@@ -56,6 +62,30 @@ const GenericDropdown = <T extends string | number>({
     setIsEmpty(false);
   };
 
+  const renderValueWithColor = (value: T) => {
+    const isPlaceholder = !value;
+
+    const colorCombination = colorMap?.[value];
+
+    return (
+      <Box
+        sx={{
+          backgroundColor: colorCombination?.bg || (isPlaceholder ? 'transparent' : undefined),
+          color: colorCombination?.font || (isPlaceholder ? 'gray' : undefined),
+          borderRadius: 30,
+          padding: '0 12px',
+          fontSize: '0.875rem',
+          lineHeight: '30px',
+          height: isPlaceholder ? 30 : 'auto',
+          minWidth: 150,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {isPlaceholder ? placeholder : value}
+      </Box>
+    );
+  };
+
   useEffect(() => {
     setOptions(defaultValue ?? '');
   }, [defaultValue]);
@@ -67,26 +97,10 @@ const GenericDropdown = <T extends string | number>({
         onChange={handleChange}
         onOpen={handleOpen}
         displayEmpty
-        renderValue={
-          renderValue ||
-          (value => (
-            <Box
-              sx={{
-                padding: '1px 10px',
-                lineHeight: '30px',
-                height: 30,
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                minWidth: 150,
-              }}
-            >
-              {String(value)}
-            </Box>
-          ))
-        }
+        renderValue={renderValue || renderValueWithColor}
         sx={{
           borderRadius: 30,
-          backgroundColor: colorMap?.[option as T] || backgroundColor || '#EDEDED',
+          background: option && colorMap?.[option]?.bg || backgroundColor || 'transparent',
           '& .MuiSelect-select': {
             padding: '1px 6px',
             fontSize: '0.875rem',
@@ -96,6 +110,11 @@ const GenericDropdown = <T extends string | number>({
             minHeight: 30,
             transition: 'height 0.2s ease',
             overflow: 'hidden',
+          },
+
+          '& .MuiMenu-paper': {
+            borderRadius: 8,
+            boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.1)',
           },
         }}
       >

--- a/src/components/modules/Task/NewTask/NewTaskForm.tsx
+++ b/src/components/modules/Task/NewTask/NewTaskForm.tsx
@@ -14,14 +14,14 @@ import GenericDropdown from '../../../common/GenericDropdown';
 import SendButton from '../../../common/SendButton';
 import { Header, Item, StyledSheet } from '../styled';
 
-const statusColorMap: Record<TaskStatus, string> = {
-  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted.bg,
-  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss.bg,
-  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision.bg,
-  [TaskStatus.DELAYED]: statusChipColorCombination.delayed.bg,
-  [TaskStatus.POSTPONED]: statusChipColorCombination.postpone.bg,
-  [TaskStatus.DONE]: statusChipColorCombination.done.bg,
-  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled.bg,
+const statusColorMap: Record<TaskStatus, { bg: string; font: string }> = {
+  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted,
+  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss,
+  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision,
+  [TaskStatus.DELAYED]: statusChipColorCombination.delayed,
+  [TaskStatus.POSTPONED]: statusChipColorCombination.postponed,
+  [TaskStatus.DONE]: statusChipColorCombination.done,
+  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled,
 };
 
 interface NewTaskFormProps {

--- a/src/components/modules/Task/TableTask/TaskTable.tsx
+++ b/src/components/modules/Task/TableTask/TaskTable.tsx
@@ -24,14 +24,14 @@ import DeleteModal from '../../../common/DeleteModal';
 import GenericDropdown from '../../../common/GenericDropdown';
 import TaskActionsMenu from '../../../common/TaskActionsMenu';
 
-const statusColorMap: Record<TaskStatus, string> = {
-  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted.bg,
-  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss.bg,
-  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision.bg,
-  [TaskStatus.DELAYED]: statusChipColorCombination.delayed.bg,
-  [TaskStatus.POSTPONED]: statusChipColorCombination.postpone.bg,
-  [TaskStatus.DONE]: statusChipColorCombination.done.bg,
-  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled.bg,
+const statusColorMap: Record<TaskStatus, { bg: string; font: string }> = {
+  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted,
+  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss,
+  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision,
+  [TaskStatus.DELAYED]: statusChipColorCombination.delayed,
+  [TaskStatus.POSTPONED]: statusChipColorCombination.postponed,
+  [TaskStatus.DONE]: statusChipColorCombination.done,
+  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled,
 };
 
 interface TaskTableProps {

--- a/src/components/modules/Task/TaskListTable.tsx
+++ b/src/components/modules/Task/TaskListTable.tsx
@@ -22,14 +22,14 @@ type TaskListTableProps = {
   setTotalProjectHours: (update: (prev: number) => number) => void;
 };
 
-const statusColorMap: Record<TaskStatus, string> = {
-  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted.bg,
-  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss.bg,
-  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision.bg,
-  [TaskStatus.DELAYED]: statusChipColorCombination.delayed.bg,
-  [TaskStatus.POSTPONED]: statusChipColorCombination.postpone.bg,
-  [TaskStatus.DONE]: statusChipColorCombination.done.bg,
-  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled.bg,
+const statusColorMap: Record<TaskStatus, { bg: string; font: string }> = {
+  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted,
+  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss,
+  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision,
+  [TaskStatus.DELAYED]: statusChipColorCombination.delayed,
+  [TaskStatus.POSTPONED]: statusChipColorCombination.postponed,
+  [TaskStatus.DONE]: statusChipColorCombination.done,
+  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled,
 };
 
 const TaskListTable = ({ projectId, onDelete, setTotalProjectHours }: TaskListTableProps) => {

--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -14,14 +14,14 @@ import GenericDropdown from '../../../common/GenericDropdown';
 import ModifyButton from '../../../common/ModifyButton';
 import { Header, Item, StyledSheet } from '../styled';
 
-const statusColorMap: Record<TaskStatus, string> = {
-  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted.bg,
-  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss.bg,
-  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision.bg,
-  [TaskStatus.DELAYED]: statusChipColorCombination.delayed.bg,
-  [TaskStatus.POSTPONED]: statusChipColorCombination.postpone.bg,
-  [TaskStatus.DONE]: statusChipColorCombination.done.bg,
-  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled.bg,
+const statusColorMap: Record<TaskStatus, { bg: string; font: string }> = {
+  [TaskStatus.NOT_STARTED]: statusChipColorCombination.notStarted,
+  [TaskStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss,
+  [TaskStatus.UNDER_REVISION]: statusChipColorCombination.underRevision,
+  [TaskStatus.DELAYED]: statusChipColorCombination.delayed,
+  [TaskStatus.POSTPONED]: statusChipColorCombination.postponed,
+  [TaskStatus.DONE]: statusChipColorCombination.done,
+  [TaskStatus.CANCELLED]: statusChipColorCombination.cancelled,
 };
 
 interface UpdateTaskFormProps {

--- a/src/pages/Projects/details.tsx
+++ b/src/pages/Projects/details.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
-import colors from '../../colors';
+import colors, { statusChipColorCombination } from '../../colors';
 import GoBack from '../../components/common/GoBack';
 import { TaskListTable } from '../../components/modules/Task/TaskListTable';
 import useHttp from '../../hooks/useHttp';
@@ -22,16 +22,16 @@ import useDeleteTask from '../../hooks/useDeleteTask';
 import { ProjectStatus } from '../../types/project';
 import { formatDate } from '../../utils/methods';
 
-const statusColorMap: Record<ProjectStatus, string> = {
-  [ProjectStatus.ACCEPTED]: colors.gold,
-  [ProjectStatus.NOT_STARTED]: colors.notStarted,
-  [ProjectStatus.IN_PROGRESS]: colors.darkPurple,
-  [ProjectStatus.UNDER_REVISION]: colors.purple,
-  [ProjectStatus.IN_QUOTATION]: colors.darkerBlue,
-  [ProjectStatus.DELAYED]: colors.delayed,
-  [ProjectStatus.POSTPONED]: colors.blue,
-  [ProjectStatus.DONE]: colors.success,
-  [ProjectStatus.CANCELLED]: colors.danger,
+const statusColorMap: Record<ProjectStatus, { bg: string; font: string }> = {
+  [ProjectStatus.ACCEPTED]: statusChipColorCombination.accepted,
+  [ProjectStatus.NOT_STARTED]: statusChipColorCombination.notStarted,
+  [ProjectStatus.IN_PROGRESS]: statusChipColorCombination.inProgerss,
+  [ProjectStatus.UNDER_REVISION]: statusChipColorCombination.underRevision,
+  [ProjectStatus.IN_QUOTATION]: statusChipColorCombination.inQuotation,
+  [ProjectStatus.DELAYED]: statusChipColorCombination.delayed,
+  [ProjectStatus.POSTPONED]: statusChipColorCombination.postponed,
+  [ProjectStatus.DONE]: statusChipColorCombination.done,
+  [ProjectStatus.CANCELLED]: statusChipColorCombination.cancelled,
 };
 
 const chipStyle = {


### PR DESCRIPTION
## refactor(GenericDropdownStyles): updated the generic dropdown styles

### Descripción

El componente ahora acepta colores para el fondo y texto de las opciones. Resolviendo el  [issue #186](https://github.com/orgs/Black-Dot-2024/projects/7/views/2?sliceBy%5Bvalue%5D=Nuevo&pane=issue&itemId=62288751).

### Cambios realizados

- Estructura del componente generic dropdown 
- Tasks/new.tsx colorMap
- Tasks/assigned.tsx colorMap
- Task/TableTask/TaskTable.tsx colorMap
- UpdateTask/UpdateTaskForm.tsx colorMap
- TaskListTable.tsx colorMap
- Proyect/details.tsx colorMap
- Task/NewTask/TaskForm.tsx colorMap

### Definición de Done

- [ ] El código ha sido revisado por al menos un miembro del equipo.
- [ ] Todas las pruebas pasan localmente.
- [ ] El código sigue los estándares de codificación y las mejores prácticas del proyecto.
- [ ] La documentación ha sido actualizada (si corresponde).
- [ ] Cualquier nueva dependencia está documentada y justificada.
- [ ] Los cambios han sido probados en un entorno de preparación (si corresponde).

### ScreenShot de la pagina 

#### Project Details

![Screenshot from 2024-05-09 10-35-16](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/46fe131d-9fb6-4ef8-994a-a68ad566c82c)

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/3fa9ea65-9758-4adc-8d92-cbd13c80ce1e)

#### Create Task

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/188512f8-46f2-4329-989a-e9ba8843a3ca)


#### Assigned Task

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/6642e574-6962-4293-a00a-d9c28b0c833d)

#### Update Task

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/c5e6ec32-3567-49eb-81cd-01a56053f322)
