### PR TITLE
Fix/tasks fields validators

### DIFF
--- a/src/components/modules/Task/NewTask/NewTaskForm.tsx
+++ b/src/components/modules/Task/NewTask/NewTaskForm.tsx
@@ -102,7 +102,6 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
     }
   };
 
-
   const handleStartDateChange = (date: dayjs.Dayjs | null) => {
     if (date && dueDate && date.isAfter(dueDate)) {
       setState({
@@ -141,7 +140,6 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
   };
 
   const handleWorkedHoursChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-
     const newValue = event.target.value;
 
     if (!/^\d*\.?\d*$/.test(newValue)) {
@@ -150,14 +148,21 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
       return;
     }
 
-    if( newValue.length > 8) {
-      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours cannot be longer than 8 characters' }));
-      setState({ open: true, message: 'Worked hours cannot be longer than 8 characters.', type: 'danger' });
+    if (newValue.length > 8) {
+      setErrors(prevErrors => ({
+        ...prevErrors,
+        workedHours: 'Worked hours cannot be longer than 8 characters',
+      }));
+      setState({
+        open: true,
+        message: 'Worked hours cannot be longer than 8 characters.',
+        type: 'danger',
+      });
       return;
     }
 
     setWorkedHours(event.target.value);
-    
+
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });

--- a/src/components/modules/Task/NewTask/NewTaskForm.tsx
+++ b/src/components/modules/Task/NewTask/NewTaskForm.tsx
@@ -51,14 +51,25 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
   const [dueDate, setDueDate] = useState<dayjs.Dayjs | null>(null);
   const [status, setStatus] = useState<TaskStatus | ''>('');
   const [assignedEmployee, setAssignedEmployee] = useState<string | ''>('');
-  const [workedHours, setWorkedHours] = useState<string | null>(null);
+  const [workedHours, setWorkedHours] = useState<string | ''>('');
   const [state, setState] = useState<SnackbarState>({ open: false, message: '' });
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const navigate = useNavigate();
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newTitle = event.target.value;
+
+    if (newTitle.length > 70) {
+      setErrors(prevErrors => ({ ...prevErrors, title: '' }));
+      return setState({
+        open: true,
+        message: 'Title cannot be longer than 70 characters',
+        type: 'danger',
+      });
+    }
     setTitle(event.target.value);
+
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, title: 'Title is required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
@@ -69,7 +80,19 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
   };
 
   const handleDescriptionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newDescription = event.target.value;
+
+    if (newDescription.length > 256) {
+      setErrors(prevErrors => ({ ...prevErrors, description: '' }));
+      setState({
+        open: true,
+        message: 'Description cannot be longer than 256 characters',
+        type: 'danger',
+      });
+      return;
+    }
     setDescription(event.target.value);
+
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, description: 'Description is required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
@@ -78,6 +101,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
       setState({ open: false, message: '' });
     }
   };
+
 
   const handleStartDateChange = (date: dayjs.Dayjs | null) => {
     if (date && dueDate && date.isAfter(dueDate)) {
@@ -117,7 +141,23 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
   };
 
   const handleWorkedHoursChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+
+    const newValue = event.target.value;
+
+    if (!/^\d*\.?\d*$/.test(newValue)) {
+      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Only numbers are allowed' }));
+      setState({ open: true, message: 'Worked hours can only be numbers.', type: 'danger' });
+      return;
+    }
+
+    if( newValue.length > 8) {
+      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours cannot be longer than 8 characters' }));
+      setState({ open: true, message: 'Worked hours cannot be longer than 8 characters.', type: 'danger' });
+      return;
+    }
+
     setWorkedHours(event.target.value);
+    
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
@@ -126,6 +166,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
       setState({ open: false, message: '' });
     }
   };
+
   const getEmployeeNames = () => {
     return employees.map(employee => employee.firstName + ' ' + employee.lastName);
   };
@@ -163,7 +204,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
     setDueDate(null);
     setStatus('');
     setAssignedEmployee('');
-    setWorkedHours(null);
+    setWorkedHours('');
   };
 
   const hasErrors = () => {
@@ -172,6 +213,13 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
 
   const hasEmptyFields = () => {
     return !title || !description || !startDate || !dueDate || !status || !assignedEmployee;
+  };
+
+  const hasWrongLength = () => {
+    if (title.length > 70 || description.length > 256 || workedHours.toString().length > 8) {
+      console.log('wrong length');
+      return true;
+    }
   };
 
   const datesAreNotValid = () => {
@@ -321,7 +369,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
           <Item>
             <SendButton
               onClick={handleSubmit}
-              disabled={hasErrors() || hasEmptyFields() || datesAreNotValid()}
+              disabled={hasErrors() || hasEmptyFields() || datesAreNotValid() || hasWrongLength()}
             />
           </Item>
         </Grid>

--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -139,7 +139,6 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleWorkedHoursChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-
     const newValue = event.target.value;
 
     if (!/^\d*\.?\d*$/.test(newValue)) {
@@ -148,14 +147,21 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
       return;
     }
 
-    if( newValue.length > 8) {
-      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours cannot be longer than 8 characters' }));
-      setState({ open: true, message: 'Worked hours cannot be longer than 8 characters.', type: 'danger' });
+    if (newValue.length > 8) {
+      setErrors(prevErrors => ({
+        ...prevErrors,
+        workedHours: 'Worked hours cannot be longer than 8 characters',
+      }));
+      setState({
+        open: true,
+        message: 'Worked hours cannot be longer than 8 characters.',
+        type: 'danger',
+      });
       return;
     }
 
     setWorkedHours(event.target.value);
-    
+
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });

--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -50,14 +50,25 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   const [dueDate, setDueDate] = useState<dayjs.Dayjs | null>(null);
   const [status, setStatus] = useState<TaskStatus | ''>('');
   const [assignedEmployee, setAssignedEmployee] = useState<string | ''>('');
-  const [workedHours, setWorkedHours] = useState<string | null>(null);
+  const [workedHours, setWorkedHours] = useState<string | ''>('');
   const [state, setState] = useState<SnackbarState>({ open: false, message: '' });
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const navigate = useNavigate();
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newTitle = event.target.value;
+
+    if (newTitle.length > 70) {
+      setErrors(prevErrors => ({ ...prevErrors, title: '' }));
+      return setState({
+        open: true,
+        message: 'Title cannot be longer than 70 characters',
+        type: 'danger',
+      });
+    }
     setTitle(event.target.value);
+
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, title: 'Title is required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
@@ -68,7 +79,19 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleDescriptionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newDescription = event.target.value;
+
+    if (newDescription.length > 256) {
+      setErrors(prevErrors => ({ ...prevErrors, description: '' }));
+      setState({
+        open: true,
+        message: 'Description cannot be longer than 256 characters',
+        type: 'danger',
+      });
+      return;
+    }
     setDescription(event.target.value);
+
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, description: 'Description is required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
@@ -116,8 +139,23 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleWorkedHoursChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setWorkedHours(event.target.value);
 
+    const newValue = event.target.value;
+
+    if (!/^\d*\.?\d*$/.test(newValue)) {
+      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Only numbers are allowed' }));
+      setState({ open: true, message: 'Worked hours can only be numbers.', type: 'danger' });
+      return;
+    }
+
+    if( newValue.length > 8) {
+      setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours cannot be longer than 8 characters' }));
+      setState({ open: true, message: 'Worked hours cannot be longer than 8 characters.', type: 'danger' });
+      return;
+    }
+
+    setWorkedHours(event.target.value);
+    
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
       setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
@@ -205,6 +243,13 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
       !assignedEmployee ||
       !workedHours
     );
+  };
+
+  const hasWrongLength = () => {
+    if (title.length > 70 || description.length > 256 || workedHours.toString().length > 8) {
+      console.log('wrong length');
+      return true;
+    }
   };
 
   const datesAreNotValid = () => {
@@ -333,7 +378,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
           <Item>
             <ModifyButton
               onClick={handleSubmit}
-              disabled={hasErrors() || hasEmptyFields() || datesAreNotValid()}
+              disabled={hasErrors() || hasEmptyFields() || datesAreNotValid() || hasWrongLength()}
             />
           </Item>
         </Grid>


### PR DESCRIPTION
## RF25 and RF05: Fields length are now validated when creating and updating a task

[RF25 and RF05]: Fields length are now validated when creating and updating a task

### Descripción

- Se solucionaron los defectos [242](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439553), [243](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439593), [244](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439620), [245](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439688), [246](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439858), [247](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439874), [249](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439946) y [250](https://github.com/orgs/Black-Dot-2024/projects/7/views/1?pane=issue&itemId=62439982).

### Cambios realizados

- Se agregó una validación de largo de título en la creación y actualización de tareas.
- Se agregó una validación de largo de descripción en la creación y actualización de tareas.
- Se agregó una validación de largo de horas trabajadas en la creación y actualización de tareas.
- Se agregó una validación de caracteres que no sean números en horas trabajadas en la creación y actualización de tasks.

### ScreenShot de la pagina 

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/93755653/8004f2dc-7473-4f0d-932d-8f30446f81e5



