### PR TITLE
refactor(GenericDropdownStyles): new styles for dropdown

### DIFF
--- a/src/components/common/GenericDropdown.tsx
+++ b/src/components/common/GenericDropdown.tsx
@@ -1,3 +1,4 @@
+import { KeyboardArrowDown } from '@mui/icons-material';
 import { Box } from '@mui/joy';
 import { FormControl, MenuItem, Select, SelectChangeEvent, SelectProps } from '@mui/material';
 import React, { useEffect, useState } from 'react';
@@ -77,7 +78,7 @@ const GenericDropdown = <T extends string | number>({
           fontSize: '0.875rem',
           lineHeight: '30px',
           height: isPlaceholder ? 30 : 'auto',
-          minWidth: 150,
+          minWidth: 50,
           whiteSpace: 'nowrap',
         }}
       >
@@ -98,6 +99,18 @@ const GenericDropdown = <T extends string | number>({
         onOpen={handleOpen}
         displayEmpty
         renderValue={renderValue || renderValueWithColor}
+        variant='standard'
+        disableUnderline={true}
+        IconComponent={() => (
+          <Box
+            sx={{
+              color: (option && colorMap?.[option]?.font) || 'inherit',
+              marginRight: '8px',
+            }}
+          >
+            <KeyboardArrowDown />
+          </Box>
+        )}
         sx={{
           borderRadius: 30,
           background: (option && colorMap?.[option]?.bg) || backgroundColor || 'transparent',

--- a/src/components/common/GenericDropdown.tsx
+++ b/src/components/common/GenericDropdown.tsx
@@ -77,7 +77,7 @@ const GenericDropdown = <T extends string | number>({
           padding: '0 12px',
           fontSize: '0.875rem',
           lineHeight: '30px',
-          height: isPlaceholder ? 30 : 'auto',
+          height: isPlaceholder ? 25 : 'auto',
           minWidth: 50,
           whiteSpace: 'nowrap',
         }}
@@ -119,7 +119,7 @@ const GenericDropdown = <T extends string | number>({
             fontSize: '0.875rem',
             textAlign: 'center',
             lineHeight: '30px',
-            height: isEmpty ? 30 : 'auto',
+            height: isEmpty ? 25 : 'auto',
             minHeight: 30,
             transition: 'height 0.2s ease',
             overflow: 'hidden',


### PR DESCRIPTION
## refactor/dropdown-style

Refactored dropdown styles. 

## UI

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/85c88094-7672-421b-bb8c-2d4507887180)
