### PR TITLE
fix(RF21): Project with '.' downloads with wrong extension

### DIFF
--- a/src/pages/Projects/report.tsx
+++ b/src/pages/Projects/report.tsx
@@ -274,7 +274,7 @@ const ProjectReport: React.FC = () => {
                     <Box>
                       <PDFDownloadLink
                         document={<ProjectReportPDF data={report} />}
-                        fileName={`report_${report.project.name}`}
+                        fileName={`report_${report.project.name}.pdf`}
                       >
                         <img src={download} alt='Download' className='w-6' />
                       </PDFDownloadLink>


### PR DESCRIPTION
## Fix/RF21: Descargar un reporte pdf con extensión incorrecta

### Descripción

[Fix/RF21]: Descargar un reporte pdf con extensión incorrecta

### Descripción

Si un proyecto tiene de nombre `<nombre>.<nombre>` el pdf se descarga con extensión incorrecta

### Cambios realizados

- Se modifica `src/pages/Projects/report.tsx`

### Story Points

\-

### Criterios de aceptación

\-

### Dependencias

Ninguna

