### PR TITLE
fix(RF17): ClientDeets Truncate too long names

### DIFF
--- a/src/pages/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/pages/Clients/ClientDetails/ClientDetails.tsx
@@ -77,7 +77,7 @@ const ClientDetails = () => {
   const ToggleModalArchive = () => setOpenArchive(!openArchive);
 
   return (
-    <>
+    <main>
       <Box
         sx={{
           display: 'flex',
@@ -89,7 +89,7 @@ const ClientDetails = () => {
         <GoBack />
       </Box>
 
-      <main className='bg-white rounded-xl p-6'>
+      <section className='bg-white rounded-xl p-6'>
         <ArchiveModal
           toggleModal={ToggleModalArchive}
           open={openArchive}
@@ -117,51 +117,42 @@ const ClientDetails = () => {
           }}
         ></ArchiveModal>
         {company && !loading && (
-          <section className='flex justify-between'>
-            <h2 className='text-2xl text-gold font-medium text-wrap break-all'>{company.name}</h2>
-            <section className='flex items-center gap-5'>
-              <div className='flex items-center gap-2'>
-                <Typography level='body-sm' className='mr-1'>
-                  Constitution date:
-                </Typography>
-                <Chip
-                  color='primary'
-                  variant='outlined'
-                  label={formatDate(company.constitutionDate ?? null)}
+          <>
+            <section className='flex-wrap grid grid-cols-3'>
+              <p className='grow-0 text-2xl text-gold font-medium truncate col-span-2'>
+                {company.name}
+              </p>
+              <div className="flex justify-end items-center gap-5">
+                <div className='grid grid-cols-1'>
+                  <Typography>
+                    Constitution date:
+                  </Typography>
+                  <Chip
+                    color='primary'
+                    variant='outlined'
+                    label={formatDate(company.constitutionDate ?? null)}
+                  />
+                </div>
+                <EditOutlinedIcon
+                  sx={{ width: '30px', height: '30px', cursor: 'pointer' }}
+                  className='text-gold'
+                  onClick={handleEditClick}
                 />
-              </div>
-              <EditOutlinedIcon
-                sx={{ width: '30px', height: '30px', cursor: 'pointer' }}
-                className='text-gold'
-                onClick={handleEditClick}
-              />
-              {company && (
                 <EditClientFormModal
                   open={editModalOpen}
                   setOpen={setEditModalOpen}
                   clientData={company}
                   setRefetch={setRefetch}
                 />
-              )}
-              <ArchiveOutlinedIcon
-                sx={{ width: '30px', height: '30px', cursor: 'pointer' }}
-                className='text-gold'
-                onClick={ToggleModalArchive}
-              />
-              {/* <DeleteOutlineOutlinedIcon
-              sx={{ width: '30px', height: '30px', cursor: 'pointer' }}
-              className='text-gold'
-              onClick={() => {
-                ToggleModalDelete();
-              }}
-            /> */}
+                <ArchiveOutlinedIcon
+                  sx={{ width: '30px', height: '30px', cursor: 'pointer' }}
+                  className='text-gold'
+                  onClick={ToggleModalArchive}
+                />
+              </div>
             </section>
-          </section>
-        )}
 
-        {!loading && company && (
-          <>
-            <section className='flex mt-8 font-montserrat justify-start gap-28'>
+            <section className='flex mt-8 justify-start gap-28'>
               <article className='flex gap-4'>
                 <EmailOutlinedIcon />
                 <p>{company.email}</p>
@@ -183,7 +174,7 @@ const ClientDetails = () => {
         )}
         <Divider sx={{ 'margin-top': '30px' }} />
         <ProjectsClientList clientId={clientId ?? ''} />
-      </main>
+      </section>
 
       {/* Snackbar */}
       <SnackbarContext.Provider value={{ state, setState }}>
@@ -191,7 +182,7 @@ const ClientDetails = () => {
           {state.message}
         </Snackbar>
       </SnackbarContext.Provider>
-    </>
+    </main>
   );
 };
 

--- a/src/pages/Clients/ClientDetails/ClientDetails.tsx
+++ b/src/pages/Clients/ClientDetails/ClientDetails.tsx
@@ -122,11 +122,9 @@ const ClientDetails = () => {
               <p className='grow-0 text-2xl text-gold font-medium truncate col-span-2'>
                 {company.name}
               </p>
-              <div className="flex justify-end items-center gap-5">
+              <div className='flex justify-end items-center gap-5'>
                 <div className='grid grid-cols-1'>
-                  <Typography>
-                    Constitution date:
-                  </Typography>
+                  <Typography>Constitution date:</Typography>
                   <Chip
                     color='primary'
                     variant='outlined'

--- a/src/pages/Projects/main.tsx
+++ b/src/pages/Projects/main.tsx
@@ -70,7 +70,7 @@ const ProjectMain = () => {
         </Link>
       </section>
       <section className='flex-1 overflow-scroll'>
-        <div className='bg-cardBg rounded-xl overflow-y-scroll grid md:grid-cols-2 lg:grid-cols-3 flex-1 min-h-0 shadow-lg p-4 gap-5'>
+        <div className='bg-cardBg rounded-xl flex-1 grid md:grid-cols-2 lg:grid-cols-3 min-h-0 shadow-lg p-4 gap-5'>
           {isLoading && <Loader />}
           {!(isLoading && filteredProjects) &&
             filteredProjects.map(project => (
@@ -86,7 +86,7 @@ const ProjectMain = () => {
             ))}
         </div>
       </section>
-    </main>
+    </main>  
   );
 };
 

--- a/src/pages/Projects/main.tsx
+++ b/src/pages/Projects/main.tsx
@@ -86,7 +86,7 @@ const ProjectMain = () => {
             ))}
         </div>
       </section>
-    </main>  
+    </main>
   );
 };
 


### PR DESCRIPTION
## Fix/RF17: ClientDeets truncate too long names

[Fix/RF17]: ClientDeets Truncate too long names

### Descripción

Se arregla PR: closes #287

### Cambios realizados

- Se modifica `src/pages/Clients/ClientDetails/ClientDetails`
- Se modifica `src/pages/Projects/main.tsx`

### Story Points

\-

### Criterios de aceptación

- [X] El texto no debe desbordarse y hacer que la página se rompa o salga de los límites

### Dependencias

Ninguna

### ScreenShot de la pagina 

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91692094/945def99-9f15-4468-9184-25a40f23dd54


