### PR TITLE
fix(RF25): Specific messages for missing fields on Snackbar

### DIFF
--- a/src/components/modules/Task/NewTask/NewTaskForm.tsx
+++ b/src/components/modules/Task/NewTask/NewTaskForm.tsx
@@ -335,6 +335,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
               onChange={handleWorkedHoursChange}
               sx={{
                 color: colors.gray,
+                borderColor: errors['workedHours'] ? colors.danger : undefined,
               }}
             />
           </Item>

--- a/src/components/modules/Task/NewTask/NewTaskForm.tsx
+++ b/src/components/modules/Task/NewTask/NewTaskForm.tsx
@@ -72,7 +72,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
 
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, title: 'Title is required' }));
-      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+      setState({ open: true, message: 'Title is required.', type: 'danger' });
     } else {
       setErrors(prevErrors => ({ ...prevErrors, title: '' }));
       setState({ open: false, message: '' });
@@ -95,7 +95,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
 
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, description: 'Description is required' }));
-      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+      setState({ open: true, message: 'Description is required.', type: 'danger' });
     } else {
       setErrors(prevErrors => ({ ...prevErrors, description: '' }));
       setState({ open: false, message: '' });
@@ -165,7 +165,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
 
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
-      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+      setState({ open: true, message: 'Worked hours are required.', type: 'danger' });
     } else {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: '' }));
       setState({ open: false, message: '' });

--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -71,7 +71,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
 
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, title: 'Title is required' }));
-      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+      setState({ open: true, message: 'Title is required.', type: 'danger' });
     } else {
       setErrors(prevErrors => ({ ...prevErrors, title: '' }));
       setState({ open: false, message: '' });
@@ -94,7 +94,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
 
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, description: 'Description is required' }));
-      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+      setState({ open: true, message: 'Description is required.', type: 'danger' });
     } else {
       setErrors(prevErrors => ({ ...prevErrors, description: '' }));
       setState({ open: false, message: '' });
@@ -164,7 +164,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
 
     if (!event.target.value.trim()) {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: 'Worked hours are required' }));
-      setState({ open: true, message: 'Please fill all fields.', type: 'danger' });
+      setState({ open: true, message: 'Worked hours are required.', type: 'danger' });
     } else {
       setErrors(prevErrors => ({ ...prevErrors, workedHours: '' }));
       setState({ open: false, message: '' });


### PR DESCRIPTION
## Fix/RF25: Specific messages for missing fields on Snackbar

[Fix/RF25]: Specific messages for missing fields on Snackbar

### Descripción

closes: #333 

### Cambios realizados

- Se modifica `src/components/modules/Task/NewTask/NewTaskForm`
- Se modifica `src/components/modules/Task/UpdateTask/UpdateTaskForm`

### Story Points

\-

### Criterios de aceptación

- [X] Existe un mensaje más específico sobre qué campos faltan por llenar

### Dependencias

Ninguna

### ScreenShot de la pagina 

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91692094/6973ea40-98aa-4997-8d1a-727397c0ab1a


