### PR TITLE
Fix/create task employee dropdown

### DIFF
--- a/src/pages/Tasks/new.tsx
+++ b/src/pages/Tasks/new.tsx
@@ -24,6 +24,8 @@ const NewTaskPage = () => {
   const { projectId } = useParams<{ projectId: string }>();
   const { employee } = useContext(EmployeeContext);
 
+  console.log('employee', employee);
+
   const {
     data: cachedEmployees,
     sendRequest: sendEmployeeRequest,
@@ -95,9 +97,18 @@ const filterEmployees = (
   currentUser: EmployeeBodyType
 ): EmployeeEntity[] => {
   const isAdmin = currentUser.role === 'Admin';
+  const hasDepartment = currentUser.department === 'Without Department';
+
+  if (!isAdmin && !hasDepartment) {
+    return [];
+  }
+
   const filteredEmployees = isAdmin
     ? employees
-    : employees.filter(emp => emp.idDepartment === currentUser.employee.idDepartment);
+    : employees.filter(
+        emp =>
+          emp.idDepartment === currentUser.employee.idDepartment && currentUser.role !== 'Admin'
+      );
 
   return filteredEmployees.sort((a, b) =>
     `${a.firstName} ${a.lastName}`.localeCompare(`${b.firstName} ${b.lastName}`)

--- a/src/pages/Tasks/new.tsx
+++ b/src/pages/Tasks/new.tsx
@@ -99,16 +99,13 @@ const filterEmployees = (
   const isAdmin = currentUser.role === 'Admin';
   const hasDepartment = currentUser.department === 'Without Department';
 
-  if (!isAdmin && !hasDepartment) {
+  if (hasDepartment) {
     return [];
   }
 
   const filteredEmployees = isAdmin
     ? employees
-    : employees.filter(
-        emp =>
-          emp.idDepartment === currentUser.employee.idDepartment && currentUser.role !== 'Admin'
-      );
+    : employees.filter(emp => emp.idDepartment === currentUser.employee.idDepartment);
 
   return filteredEmployees.sort((a, b) =>
     `${a.firstName} ${a.lastName}`.localeCompare(`${b.firstName} ${b.lastName}`)

--- a/src/pages/Tasks/update.tsx
+++ b/src/pages/Tasks/update.tsx
@@ -103,6 +103,12 @@ const filterEmployees = (
   currentUser: EmployeeBodyType
 ): EmployeeEntity[] => {
   const isAdmin = currentUser.role === 'Admin';
+  const hasDepartment = currentUser.department === 'Without Department';
+
+  if (hasDepartment) {
+    return [];
+  }
+
   const filteredEmployees = isAdmin
     ? employees
     : employees.filter(emp => emp.idDepartment === currentUser.employee.idDepartment);

--- a/src/pages/Tasks/update.tsx
+++ b/src/pages/Tasks/update.tsx
@@ -1,9 +1,10 @@
 import { Box, Typography } from '@mui/joy';
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import colors from '../../colors';
 import Loader from '../../components/common/Loader';
 import UpdateTaskForm from '../../components/modules/Task/UpdateTask/UpdateTaskForm';
+import { EmployeeBodyType, EmployeeContext } from '../../hooks/employeeContext';
 import useHttp from '../../hooks/useHttp';
 import { EmployeeEntity } from '../../types/employee';
 import { Response } from '../../types/response';
@@ -11,11 +12,12 @@ import { TaskDetail, UpdatedTask } from '../../types/task';
 import { APIPath, RequestMethods } from '../../utils/constants';
 
 const UpdateTaskPage: React.FC = () => {
+  const { employee } = useContext(EmployeeContext);
   const { id } = useParams();
 
   const { data: cachedEmployees, sendRequest: sendEmployeeRequest } = useHttp<
     Response<EmployeeEntity>
-  >(`/employee/getAllEmployees`, RequestMethods.GET);
+  >(`/employee/getEmployees`, RequestMethods.GET);
 
   const [employees, setEmployees] = useState<EmployeeEntity[]>([]);
 
@@ -25,10 +27,10 @@ const UpdateTaskPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (cachedEmployees) {
-      setEmployees(cachedEmployees.data);
+    if (employee?.employee) {
+      setEmployees(filterEmployees(cachedEmployees?.data || [], employee));
     }
-  }, [cachedEmployees]);
+  }, [employee, cachedEmployees]);
 
   const { data: cachedTask, sendRequest: sendGetTaskRequest } = useHttp<TaskDetail>(
     `${APIPath.TASK_DETAIL}/${id}`,
@@ -81,6 +83,32 @@ const UpdateTaskPage: React.FC = () => {
       onSubmit={handleOnSubmit}
       employees={employees || []}
     />
+  );
+};
+
+/**
+ * Filters the employees based on the current user's role and department.
+ *
+ * Admin users can see all employees, while other users can only see
+ * employees in their department.
+ *
+ * @param employees: EmployeeEntity[] - The list of employees to filter
+ * @param currentUser: EmployeeBodyType - The current user's details
+ *
+ * @returns EmployeeEntity[] - The filtered list of employees based
+ *          on the current user and in alphabetical order
+ */
+const filterEmployees = (
+  employees: EmployeeEntity[],
+  currentUser: EmployeeBodyType
+): EmployeeEntity[] => {
+  const isAdmin = currentUser.role === 'Admin';
+  const filteredEmployees = isAdmin
+    ? employees
+    : employees.filter(emp => emp.idDepartment === currentUser.employee.idDepartment);
+
+  return filteredEmployees.sort((a, b) =>
+    `${a.firstName} ${a.lastName}`.localeCompare(`${b.firstName} ${b.lastName}`)
   );
 };
 


### PR DESCRIPTION
## Fix/create-task-employee-dropdown

### Descripción

- Muestra una empty list si el usuario no tiene departamento
- Muestra solo los empleados de cada area en editar tarea. 

### Issues

- closes #372 
- closes #374 
- closes #378 

### Cambios realizados

- Nueva validación para validar si un usuario no tiene departamento

### ScreenShot / Video

#### Admin

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/b31b4c6c-ce93-45cf-bf16-6b7d8806f4c0)

#### Legal

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/75867326/a8c792a4-0bd1-42f9-8363-fd1f2041c3dc)
