### PR TITLE
RF05-25: Tasks now POST correctly when employee or end date are null. Button now disables when it is posting to avoid exploits.

### DIFF
--- a/src/components/modules/Task/NewTask/NewTaskForm.tsx
+++ b/src/components/modules/Task/NewTask/NewTaskForm.tsx
@@ -48,12 +48,13 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [startDate, setStartDate] = useState<dayjs.Dayjs | null>(null);
-  const [dueDate, setDueDate] = useState<dayjs.Dayjs | null>(null);
+  const [endDate, setEndDate] = useState<dayjs.Dayjs | null>(null);
   const [status, setStatus] = useState<TaskStatus | ''>('');
   const [assignedEmployee, setAssignedEmployee] = useState<string | ''>('');
   const [workedHours, setWorkedHours] = useState<string | ''>('');
   const [state, setState] = useState<SnackbarState>({ open: false, message: '' });
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isPosting, setIsPosting] = useState(false);
 
   const navigate = useNavigate();
 
@@ -103,10 +104,10 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
   };
 
   const handleStartDateChange = (date: dayjs.Dayjs | null) => {
-    if (date && dueDate && date.isAfter(dueDate)) {
+    if (date && endDate && date.isAfter(endDate)) {
       setState({
         open: true,
-        message: 'Start date cannot be after due date.',
+        message: 'Start date cannot be after end date.',
         type: 'danger',
       });
     } else {
@@ -115,13 +116,13 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
     setStartDate(date);
   };
 
-  const handleDueDateChange = (date: dayjs.Dayjs | null) => {
+  const handleEndDateChange = (date: dayjs.Dayjs | null) => {
     const datesAreNotValid = date && dayjs(date).isBefore(dayjs(startDate));
 
     if (datesAreNotValid) {
       setState({
         open: true,
-        message: 'Due date cannot be before start date.',
+        message: 'End date cannot be before start date.',
         type: 'danger',
       });
     } else if (dayjs(date).isSame(dayjs(startDate))) {
@@ -130,7 +131,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
       setState({ open: false, message: '' });
     }
 
-    setDueDate(date);
+    setEndDate(date);
   };
 
   const handleStatusSelect = (value: TaskStatus) => {
@@ -176,7 +177,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
       description,
       status: status as TaskStatus,
       startDate: startDate?.toISOString() ?? '',
-      dueDate: dueDate?.toISOString() ?? '',
+      endDate: endDate !== null ? endDate?.toISOString() : null,
       workedHours: workedHours !== '' ? workedHours : '0',
       idProject: projectId,
       idEmployee: employees.find(employee => {
@@ -200,7 +201,7 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
     setTitle('');
     setDescription('');
     setStartDate(null);
-    setDueDate(null);
+    setEndDate(null);
     setStatus('');
     setAssignedEmployee('');
     setWorkedHours('');
@@ -222,8 +223,8 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
 
   const datesAreNotValid = () => {
     if (
-      (dueDate && startDate && dueDate.isBefore(startDate)) ||
-      (dueDate && startDate && startDate.isAfter(dueDate))
+      (endDate && startDate && endDate.isBefore(startDate)) ||
+      (endDate && startDate && startDate.isAfter(endDate))
     ) {
       return true;
     }
@@ -290,10 +291,10 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
             <Item>
               <FormLabel>End Date</FormLabel>
               <DatePicker
-                value={dueDate}
-                onChange={handleDueDateChange}
+                value={endDate}
+                onChange={handleEndDateChange}
                 sx={{
-                  borderColor: errors['dueDate'] ? colors.danger : undefined,
+                  borderColor: errors['endDate'] ? colors.danger : undefined,
                 }}
               />
             </Item>
@@ -379,9 +380,19 @@ const NewTaskForm: React.FC<NewTaskFormProps> = ({
             <Item>
               <SendButton
                 onClick={() => {
+                  setIsPosting(true);
                   handleSubmit();
+                  setTimeout(() => {
+                    setIsPosting(false);
+                  }, 3000);
                 }}
-                disabled={hasErrors() || hasEmptyFields() || datesAreNotValid() || hasWrongLength()}
+                disabled={
+                  hasErrors() ||
+                  hasEmptyFields() ||
+                  datesAreNotValid() ||
+                  hasWrongLength() ||
+                  isPosting
+                }
               />
             </Item>
           </Grid>

--- a/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
+++ b/src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx
@@ -47,12 +47,13 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [startDate, setStartDate] = useState<dayjs.Dayjs | null>(null);
-  const [endDate, setendDate] = useState<dayjs.Dayjs | null>(null);
+  const [endDate, setEndDate] = useState<dayjs.Dayjs | null>(null);
   const [status, setStatus] = useState<TaskStatus | ''>('');
   const [assignedEmployee, setAssignedEmployee] = useState<string | ''>('');
   const [workedHours, setWorkedHours] = useState<string | ''>('');
   const [state, setState] = useState<SnackbarState>({ open: false, message: '' });
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isPosting, setIsPosting] = useState(false);
 
   const navigate = useNavigate();
 
@@ -120,7 +121,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
     if (datesAreNotValid) {
       setState({
         open: true,
-        message: 'Due date cannot be before start date.',
+        message: 'End date cannot be before start date.',
         type: 'danger',
       });
     } else if (dayjs(date).isSame(dayjs(startDate))) {
@@ -129,7 +130,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
       setState({ open: false, message: '' });
     }
 
-    setendDate(date);
+    setEndDate(date);
   };
 
   const handleStatusSelect = (value: TaskStatus) => {
@@ -182,7 +183,7 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
       setTitle(data.title);
       setDescription(data.description);
       setStartDate(dayjs(data.startDate));
-      setendDate(dayjs(data.endDate));
+      setEndDate(dayjs(data.endDate));
       setStatus(data.status);
       setAssignedEmployee(data.employeeFirstName + ' ' + data.employeeLastName);
       setWorkedHours(data.workedHours?.toString() ?? '');
@@ -198,23 +199,13 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
   };
 
   const handleSubmit = async () => {
-    if (endDate && startDate && endDate.isBefore(startDate)) {
-      setErrors({
-        ...errors,
-        endDate: 'Due date cannot be before start date',
-      });
-      return;
-    }
-
-    setErrors({});
-
     const payload: UpdatedTask = {
       id: idTask as string,
       title: title,
       description: description,
       status: status as TaskStatus,
       startDate: startDate?.toISOString() ?? '',
-      endDate: endDate?.toISOString() ?? '',
+      endDate: endDate !== null ? endDate?.toISOString() : null,
       workedHours: workedHours ?? '0.0',
       idEmployee: employees.find(employee => {
         const fullName = employee.firstName + ' ' + employee.lastName;
@@ -385,8 +376,20 @@ const UpdateTaskForm: React.FC<UpdateTaskFormProps> = ({
           <Grid>
             <Item>
               <ModifyButton
-                onClick={handleSubmit}
-                disabled={hasErrors() || hasEmptyFields() || datesAreNotValid() || hasWrongLength()}
+                onClick={() => {
+                  setIsPosting(true);
+                  handleSubmit();
+                  setTimeout(() => {
+                    setIsPosting(false);
+                  }, 3000);
+                }}
+                disabled={
+                  hasErrors() ||
+                  hasEmptyFields() ||
+                  datesAreNotValid() ||
+                  hasWrongLength() ||
+                  isPosting
+                }
               />
             </Item>
           </Grid>

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -5,7 +5,7 @@ export interface BareboneTask {
   description: string;
   status: TaskStatus;
   startDate: string | null;
-  dueDate: string | null;
+  endDate: string | null;
   workedHours: string | null;
   idProject: string;
   idEmployee: string;
@@ -47,7 +47,7 @@ export interface UpdatedTask {
   description?: string;
   status?: TaskStatus;
   startDate?: string;
-  endDate?: string;
+  endDate?: string | null;
   workedHours?: string;
   idProject?: string;
   idEmployee?: string;


### PR DESCRIPTION
## TSK-RF05/25-ID00: Tasks now POST correctly when employee or end date are null. Button now disables when it is posting to avoid exploits.

### Descripción

Se corrigió el envío de endDate y employee al backend. El botón de crear y actualizar tarea ahora se desactiva cuando le haces click para evitar exploits. El botón se reactiva después de 3 segundos en caso de que no se haya posteado correctamente. Se modificó el schema de task para corregir este error.

### Issues

- closes #419
- closes #373

### Cambios realizados

- Se modificó el archivo ```src/components/modules/Task/NewTask/NewTaskForm.tsx```
- Se modificó el archivo ```src/components/modules/Task/UpdateTask/UpdateTaskForm.tsx```
- Se modificó el archivo ```src/types/task.ts```

### ScreenShot / Video

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/93755653/06360227-3d2f-44df-b404-e8fb8a4284a2