### PR TITLE
Unificar validator para RFC

### DIFF
--- a/src/components/modules/Clients/NewClientFormModal.tsx
+++ b/src/components/modules/Clients/NewClientFormModal.tsx
@@ -8,6 +8,7 @@ import { SnackbarContext } from '../../../hooks/snackbarContext';
 import useHttp from '../../../hooks/useHttp';
 import { CompanyEntity } from '../../../types/company';
 import { RequestMethods } from '../../../utils/constants';
+import { validRFC } from '../../../utils/methods';
 import CancelButton from '../../common/CancelButton';
 import CreateClientButton from './CreateClientButton';
 
@@ -128,6 +129,9 @@ const NewClientFormModal = ({ open, setOpen, setRefetch }: NewClientFormModalPro
       });
       return;
     }
+
+    if (!validRFC(companyRFC))
+      return setState({ open: true, message: 'RFC is invalid', type: 'danger' });
 
     if (!validateForm())
       return setState({ open: true, message: 'All fields are required', type: 'danger' });


### PR DESCRIPTION
### Unificar validator para RFC
- Se modificó  el modal de nuevo cliente para que el validator de RFC se igual al validator de modal para modificar.
--- 
### Recordar que una RFC válida luce así:
#### Para empresas
<img width="558" alt="Captura de pantalla 2024-05-13 a la(s) 11 20 39 a m" src="https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/105307730/e5c8b1a5-4638-49f0-a832-3fd3d8a5abdd">

#### Para personas
<img width="569" alt="Captura de pantalla 2024-05-13 a la(s) 11 21 36 a m" src="https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/105307730/b3553785-9b89-429c-9aa5-c4c01ce516bd">

---- 

```
export const validRFC = (rfc: string): boolean => {
  const regex = /^[a-zA-Z]{3,4}[0-9]{6}[a-zA-Z0-9]{3}$/;
  return regex.test(rfc);
}; 
```

