### PR TITLE
fix(RF20): Add 'January' as default month to the filter 

### DIFF
--- a/src/pages/Projects/report.tsx
+++ b/src/pages/Projects/report.tsx
@@ -90,8 +90,10 @@ const ProjectReport: React.FC = () => {
     setYear(Number(value));
   };
 
-  const handleMonthChange = (event: SyntheticEvent | null, value: string | null) => {
-    setMonth(Number(value));
+  const handleMonthChange = (event: SyntheticEvent | null, value: number | null) => {
+    if (value !== null) {
+      setMonth(value);
+    }
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -185,7 +187,7 @@ const ProjectReport: React.FC = () => {
         <section className='overflow-y-auto overflow-hidden bg-white rounded-xl p-6 '>
           <section className='flex flex-wrap justify-end gap-3 mb-5'>
             <Select
-              value={1}
+              defaultValue={1}
               placeholder='Month'
               indicator={<KeyboardArrowDown />}
               sx={{


### PR DESCRIPTION
## PROYECTO-RF20: Default month for filter

### Descripción

Se añade un mes por defecto al filtro de proyectos

### Issues

- closes #551 

### Cambios realizados

- Se añade un value dentro del Selector Month en `src/pages/Projects/report.tsx`

### ScreenShot / Video

![image](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91692094/9da39525-b5ff-4391-99af-dba8f5dabee4)