### PR TITLE
fix(frontend): report and pdf text

### DIFF
--- a/src/components/modules/Task/NewTask/TableTask/TaskRow.tsx
+++ b/src/components/modules/Task/NewTask/TableTask/TaskRow.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import dayjs from 'dayjs';
 import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';

--- a/src/pages/Projects/details.tsx
+++ b/src/pages/Projects/details.tsx
@@ -109,8 +109,6 @@ const ProjectDetails = () => {
       );
       setTotalHours(calculatedHours);
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tasks]);
 
   tasks?.data.sort((a, b) => {
@@ -137,7 +135,6 @@ const ProjectDetails = () => {
     if (company) {
       setCompanyName(company.data.name);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, company, projectStatus]);
 
   const handleStatusChange = async (newStatus: ProjectStatus) => {

--- a/src/pages/Projects/report-pdf.tsx
+++ b/src/pages/Projects/report-pdf.tsx
@@ -3,6 +3,15 @@ import colors from '../../colors';
 import { Report } from '../../types/project-report';
 import { truncateText } from '../../utils/methods';
 
+function chunkText(text: string, len: number): string {
+  let txt = '';
+  for (let i = 0; i < text.length; i += len) {
+    txt += text.substring(i, i + len > text.length ? text.length : i + len);
+    txt += '\n';
+  }
+  return txt;
+}
+
 interface reportProps {
   data: Report;
 }
@@ -90,10 +99,10 @@ const ProjectReportPDF = (props: reportProps) => {
       <Page size='A4' style={{ backgroundColor: 'white' }}>
         <View style={{ color: 'black', textAlign: 'justify', margin: 30, gap: '20px' }}>
           <Text style={{ textAlign: 'center', fontSize: 26, fontFamily: 'Times-Bold' }}>
-            {props.data.project.name}
+            {chunkText(props.data.project.name, 38)}
           </Text>
           {props.data.project.description && (
-            <Text style={{ fontSize: 14 }}>{props.data.project.description}</Text>
+            <Text style={{ fontSize: 14 }}>{chunkText(props.data.project.description, 68)}</Text>
           )}
 
           <View style={{ gap: '20px' }}>
@@ -214,13 +223,15 @@ const ProjectReportPDF = (props: reportProps) => {
               key={item.title}
             >
               <View style={{ gap: '10px' }}>
-                {tasks % 4 == 0 && (
+                {tasks % 3 == 0 && (
                   <Text break style={{ fontSize: 20 }}>
-                    {item.title}
+                    {chunkText(item.title, 47)}
                   </Text>
                 )}
-                {tasks % 4 != 0 && <Text style={{ fontSize: 20 }}>{item.title}</Text>}
-                <Text style={{ fontSize: 14 }}>{item.description}</Text>
+                {tasks % 3 != 0 && (
+                  <Text style={{ fontSize: 20 }}>{chunkText(item.title, 47)}</Text>
+                )}
+                <Text style={{ fontSize: 14 }}>{chunkText(item.description, 68)}</Text>
 
                 <View
                   style={{

--- a/src/pages/Projects/report.tsx
+++ b/src/pages/Projects/report.tsx
@@ -291,7 +291,7 @@ const ProjectReport: React.FC = () => {
                   {report.project.name}
                 </p>
               </section>
-              <section className='mb-4 xl:mb-8'>
+              <section className='mb-4 xl:mb-8 break-words'>
                 {' '}
                 <p>{report.project.description}</p>{' '}
               </section>
@@ -445,7 +445,7 @@ const ProjectReport: React.FC = () => {
                     </div>
 
                     <div className='mb-4'>
-                      <p>{item.description}</p>
+                      <p className='break-words'>{item.description}</p>
                     </div>
 
                     <div className='flex gap-4 mb-4'>

--- a/src/pages/Tasks/edit.tsx
+++ b/src/pages/Tasks/edit.tsx
@@ -25,7 +25,6 @@ const EditTaskPage: React.FC = () => {
 
   useEffect(() => {
     sendEmployeeRequest();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -48,7 +47,6 @@ const EditTaskPage: React.FC = () => {
     if (!cachedTask) {
       sendGetTaskRequest();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cachedTask]);
 
   useEffect(() => {


### PR DESCRIPTION
## Proyecto-RF21: Se ve extraño

### Descripción

Estilos para que el texto no se salga de la pantalla del sistema o la hoja del pdf.

### Issues

- closes #548 

### Cambios realizados

Se modificaron los siguientes archivos:
- report.tsx
- report-pdf.tsx

### ScreenShot / Video
![Screenshot from 2024-05-21 13-42-33](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91426086/873680eb-c20c-4892-b3a1-512f554ff375)
![Screenshot from 2024-05-21 13-42-06](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91426086/2cc98baf-182b-46a8-b12f-62fa0c8cb529)
![Screenshot from 2024-05-21 13-42-16](https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/91426086/61c021ed-6e7d-40c9-a28f-a0a626be4aa4)

