### PR TITLE
fix(sidebar): transparency

### DIFF
--- a/src/components/common/SideBar.tsx
+++ b/src/components/common/SideBar.tsx
@@ -59,9 +59,9 @@ const SideBar = () => {
 
   const SideBarContent = () => (
     <aside
-      className={`relative bg-[url('/src/assets/marmol.jpg')] bg-repeat top-0 left-0 md:flex flex-col items-center pt-16 gap-10 w-full h-full overflow-y-auto`}
+      className={`relative bg-[url('/src/assets/marmol.jpg')] bg-repeat top-0 left-0 md:flex flex-col items-center pt-16 gap-10 w-full h-full overflow-y-auto bg-black bg-opacity-50`}
     >
-      <div className='absolute top-0 left-0 w-full h-full bg-black bg-opacity-50'></div>
+      <div className='absolute top-0 left-0 w-full h-full '></div>
       <div className='relative z-10 w-full flex flex-col justify-between h-full'>
         <div>
           <div className='flex justify-center'>


### PR DESCRIPTION
## Side Bar Transparency 

### Descripción

Había un error con el comportamiento de la transparencia con la sidebar y ya funciona con congruencia

### Cambios realizados

Se cambió el **bg-black bg-opacity-50** de  un div al aside
    
### ScreenShot / Video

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/105307730/91fd58a8-f3eb-4077-982d-64c09e8d73e7
