### PR TITLE
fix(employees): refetch employees after delete

### DIFF
--- a/src/components/modules/Employees/EmployeeeTable.tsx
+++ b/src/components/modules/Employees/EmployeeeTable.tsx
@@ -46,13 +46,13 @@ export default function EmployeeTable({ searchTerm, filterOption }: Props) {
   const [currentEmployeeId, setCurrentEmployeeId] = useState<string>('');
   const [searchResults, setSearchResults] = useState<Employee[]>([]);
 
-  const { deleteEmployee, error: deletError } = useDeleteEmployee();
+  const { deleteEmployee, error: deletError, success: deleteSuccess } = useDeleteEmployee();
 
   useEffect(() => {
     reqEmployees.sendRequest();
     reqRoles.sendRequest();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [deleteSuccess, deletError]);
 
   useEffect(() => {
     if (reqEmployees.error) {

--- a/src/hooks/useDeleteEmployee.ts
+++ b/src/hooks/useDeleteEmployee.ts
@@ -5,10 +5,12 @@ import { BASE_API_URL } from '../utils/constants';
 
 const useDeleteEmployee = () => {
   const [error, setError] = useState<Error | null>(null);
+  const [success, setSuccess] = useState<boolean>(false);
 
   const deleteEmployee = async (id: string) => {
     try {
-      await axiosInstance.delete(`${BASE_API_URL}/employee/delete/${id}`);
+      const res = await axiosInstance.delete(`${BASE_API_URL}/employee/delete/${id}`);
+      if (res.status == 200) setSuccess(true);
     } catch (err: unknown) {
       if (axios.isAxiosError(err)) {
         setError(new Error(err.response?.data?.message || err.message));
@@ -18,7 +20,7 @@ const useDeleteEmployee = () => {
     }
   };
 
-  return { deleteEmployee, error };
+  return { deleteEmployee, error, success };
 };
 
 export default useDeleteEmployee;


### PR DESCRIPTION
## Employees/RF26-eliminar-empleado

### Descripción

Cuando se elimina un empleado, se vuelve a consultar todos los usuarios

### ScreenShot / Video

Muestra que los cambios realizados funcionen de la manera esperada.

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/71858836/0cc56c53-32c0-45e5-a7a8-cbaeae057910

