### PR TITLE
fix(modal): add separate states for archive and delete modals

### DIFF
--- a/src/pages/Projects/details.tsx
+++ b/src/pages/Projects/details.tsx
@@ -537,7 +537,7 @@ const ProjectDetails = () => {
             </Button>
           )}
           <Link to={id ? `${RoutesPath.TASKS}/${id}/create` : RoutesPath.TASKS}>
-            <AddButton onClick={() => { }} />
+            <AddButton onClick={() => {}} />
           </Link>
         </Box>
       </section>

--- a/src/pages/Projects/details.tsx
+++ b/src/pages/Projects/details.tsx
@@ -63,6 +63,7 @@ const ProjectDetails = () => {
   const { setState } = useContext(SnackbarContext);
   const [initialTasks, setInitialTasks] = useState<TaskDetail[]>([]);
   const [open, setOpen] = useState<boolean>(false);
+  const [openDeleteModal, setOpenDeleteModal] = useState<boolean>(false);
   const [companyName, setCompanyName] = useState<string>('');
   const [projectStatus, setProjectStatus] = useState<ProjectStatus>(ProjectStatus.NOT_STARTED);
   const [totalHours, setTotalHours] = useState<number>(0);
@@ -413,8 +414,8 @@ const ProjectDetails = () => {
             </div>
           </section>
           <DeleteModal
-            open={open}
-            setOpen={setOpen}
+            open={openDeleteModal}
+            setOpen={setOpenDeleteModal}
             title='Delete project'
             description='Every task and hours associated with this project will be eliminated.'
             id={id ?? ''}
@@ -540,7 +541,7 @@ const ProjectDetails = () => {
             </Button>
           )}
           <Link to={id ? `${RoutesPath.TASKS}/${id}/create` : RoutesPath.TASKS}>
-            <AddButton onClick={() => {}} />
+            <AddButton onClick={() => { }} />
           </Link>
         </Box>
       </section>

--- a/src/pages/Projects/details.tsx
+++ b/src/pages/Projects/details.tsx
@@ -77,10 +77,6 @@ const ProjectDetails = () => {
     RequestMethods.GET
   );
 
-  const toggleModal = () => {
-    setOpen(!open);
-  };
-
   /**
    * @description This useEffect is used to check if the error is an axios error and if the error
    * message contains 'Invalid uuid' or 'unexpected error'
@@ -365,7 +361,7 @@ const ProjectDetails = () => {
 
               {data?.isArchived ? (
                 <Button
-                  onClick={toggleModal}
+                  onClick={() => setOpen(true)}
                   sx={{
                     backgroundColor: colors.lightWhite,
                     ':hover': {
@@ -382,7 +378,7 @@ const ProjectDetails = () => {
                 </Button>
               ) : (
                 <Button
-                  onClick={toggleModal}
+                  onClick={() => setOpen(true)}
                   sx={{
                     backgroundColor: colors.lightWhite,
                     ':hover': {
@@ -400,7 +396,7 @@ const ProjectDetails = () => {
               )}
               <Button
                 onClick={() => {
-                  setOpen(true);
+                  setOpenDeleteModal(true);
                 }}
                 sx={{
                   backgroundColor: colors.lightWhite,


### PR DESCRIPTION
## Proyects-RF58: Archivar clientes

### Descripción

Se utilizó un estado separado para abrir el modal de archivar y eliminar un proyecto

### ScreenShot / Video

Muestra que los cambios realizados funcionen de la manera esperada.

https://github.com/Black-Dot-2024/Zeitgeist-FrontEnd/assets/71858836/ff091146-49d2-4c27-9b26-6704d73d6e85

